### PR TITLE
doctrine/persistence dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "contributte/di": "^0.5",
     "doctrine/cache": "^1.10",
     "doctrine/mongodb-odm": "^2.0",
-    "doctrine/persistence": "^2.1",
+    "doctrine/persistence": "^2.4 || ^3.0",
     "mongodb/mongodb": "^1.5",
     "nette/di": "^3.0",
     "nette/schema": "^1.1",


### PR DESCRIPTION
I want to use ODM besides ORM and the problem is, that doctrine/persistence dependency is too old. I'am proposing same change as in doctrine/mongodb-odm package.

Maybe you should consider update doctrine/annotations also.